### PR TITLE
SB-0002: Update issue reporting link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ There are many ways you can help:
 
 ## Reporting Issues
 
-If you find a bug or have an issue, please check the [open issues](https://github.com/subhamay-bhattacharyya-gha/create-issue-action/issues) before creating a new one. If it’s not there, feel free to open a new issue and provide as much information as possible.
+If you find a bug or have an issue, please check the [open issues](https://github.com/subhamay-bhattacharyya-gha/branch-issue-action/issues) before creating a new one. If it’s not there, feel free to open a new issue and provide as much information as possible.
 
 ## Submitting Changes
 


### PR DESCRIPTION
This pull request includes a small change to the `CONTRIBUTING.md` file. The change updates the URL in the "Reporting Issues" section to point to the correct repository for open issues.

* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L15-R15): Updated the link for checking open issues to the correct repository URL.